### PR TITLE
Integrate user into systemd unit file

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,5 +7,5 @@
 ---
 - name: restart home-assistant
   service:
-    name: "home-assistant@{{ ha_user }}"
+    name: home-assistant
     state: restarted

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -8,14 +8,14 @@
 - name: install systemd unit file
   template:
     src: home-assistant.service.j2
-    dest: "/etc/systemd/system/home-assistant@{{ ha_user }}.service"
+    dest: "/etc/systemd/system/home-assistant.service"
     owner: root
     group: root
     mode: 0644
 
 - name: start home-assistant
   systemd:
-    name: "home-assistant@{{ ha_user }}"
+    name: home-assistant
     daemon_reload: yes
     enabled: yes
     state: started

--- a/templates/home-assistant.service.j2
+++ b/templates/home-assistant.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=%i
+User={{ ha_user }}
 ExecStart=/usr/bin/hass --config {{ ha_conf_dir }}
 
 [Install]


### PR DESCRIPTION
I find that indicating the user as part of the systemd unit file name is confusing and uncommon. At the same time we don't gain any flexibility as it's as static as defining the user inside the unit file.

This PR integrates the user inside the unit file and removes it from the unit file name.