### PR TITLE
Install HA in a virtualenv

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -9,7 +9,7 @@
   pip:
     name: "{{ item }}"
     extra_args: "--upgrade"
-    executable: pip3
+    virtualenv: "{{ ha_conf_dir }}"
   with_items:
     - colorlog
 
@@ -17,12 +17,12 @@
   pip:
     name: homeassistant
     version: "{{ ha_version }}"
-    executable: pip3
+    virtualenv: "{{ ha_conf_dir }}"
   when: ha_version is defined
 
 - name: install latest version of Home Assistant
   pip:
     name: homeassistant
     extra_args: "--upgrade"
-    executable: pip3
+    virtualenv: "{{ ha_conf_dir }}"
   when: ha_version is undefined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,10 @@
 # Licensed under Apache 2.0. All rights reserved.
 #
 ---
-- include: preparation.yml
-- include: motd.yml
+- include_tasks: preparation.yml
+- include_tasks: motd.yml
   when: motd_modification | default(false)
-- include: installation.yml
-- include: systemd.yml
-- include: firewall.yml
+- include_tasks: installation.yml
+- include_tasks: systemd.yml
+- include_tasks: firewall.yml
   when: ansible_distribution == "Fedora"

--- a/tasks/preparation.yml
+++ b/tasks/preparation.yml
@@ -60,4 +60,5 @@
   with_items:
     - appdirs
     - packaging
+    - python-dateutil
   when: ansible_distribution == "Debian"

--- a/tasks/preparation.yml
+++ b/tasks/preparation.yml
@@ -5,6 +5,21 @@
 # Licensed under Apache 2.0. All rights reserved.
 #
 ---
+- name: create user
+  user:
+    name: "{{ ha_user }}"
+    comment: "Home Assistant"
+    system: yes
+    shell: "/sbin/nologin"
+
+- name: create directory
+  file:
+    path: "{{ ha_conf_dir }}"
+    state: directory
+    mode: 02775
+    owner: "{{ ha_user }}"
+    group: "{{ ha_user }}"
+
 - name: install commonly-named packages
   package:
     name: "{{ item }}"
@@ -46,18 +61,3 @@
     - appdirs
     - packaging
   when: ansible_distribution == "Debian"
-
-- name: create user
-  user:
-    name: "{{ ha_user }}"
-    comment: "Home Assistant"
-    system: yes
-    shell: "/sbin/nologin"
-
-- name: create directory
-  file:
-    path: "{{ ha_conf_dir }}"
-    state: directory
-    mode: 02775
-    owner: "{{ ha_user }}"
-    group: "{{ ha_user }}"

--- a/tasks/preparation.yml
+++ b/tasks/preparation.yml
@@ -41,7 +41,7 @@
   pip:
     name: "{{ item }}"
     state: present
-    executable: pip3
+    virtualenv: "{{ ha_conf_dir }}"
   with_items:
     - appdirs
     - packaging

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -5,9 +5,6 @@
 # Licensed under Apache 2.0. All rights reserved.
 #
 ---
-- shell: which hass
-  register: hass_command
-
 - name: install fedora systemd unit file
   template:
     src: home-assistant.service.j2

--- a/templates/home-assistant.service.j2
+++ b/templates/home-assistant.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User={{ ha_user }}
-ExecStart={{ hass_command.stdout }} --config {{ ha_conf_dir }}
+ExecStart={{ ha_conf_dir }}/bin/hass --config {{ ha_conf_dir }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With strict enforcement of [PEP-668](https://peps.python.org/pep-0668/) e.g. in Debian 12, the installation of `hass` as system-wide package fails. This PR changes the ansible role to install `hass` in a virtualenv within the chosen config directory.